### PR TITLE
Fix: Do not validate composer.json and composer.lock in strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,5 +49,5 @@ tests: vendor ## Runs auto-review, unit, and integration tests with phpunit/phpu
 	vendor/bin/phpunit --configuration=test/Integration/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer validate --strict
+	composer validate
 	composer install --no-interaction --no-progress


### PR DESCRIPTION
This pull request

* [x] stops validating `composer.json` and `composer.lock` in strict mode

Follows #2.

💁‍♂️ Forgot to adjust `Makefile` in ed1d2c1.