### PR TITLE
Enhancement: Use Php74 rule set

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -26,7 +26,7 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php73($license->header()));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php74($license->header()));
 
 $config->getFinder()
     ->exclude([


### PR DESCRIPTION
This pull request

* [x] uses the `Php74` rule set from [`ergebnis/php-cs-fixer-config`](https://github.com/ergebnis/php-cs-fixer-config)